### PR TITLE
Do not process events that happen inside a child scope

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,24 +19,24 @@ const extend = Object.assign
 
 const matches = (ev, sel) => !sel || (ev.target && selmatch(ev.target, sel))
 
-const boundaryMakerAttr = "data-scope-boundary";
+const boundaryMakerAttr = "data-scope-boundary"
 
-const isScopeBoundary = (el) => el.hasAttribute && el.hasAttribute(boundaryMakerAttr);
+const isScopeBoundary = (el) => el.hasAttribute && el.hasAttribute(boundaryMakerAttr)
 
 const belongsToScope = (ev) => {
-  const scopeRoot = ev.currentTarget;
-  let currentEl = ev.target;
+  const scopeRoot = ev.currentTarget
+  let currentEl = ev.target
   while(currentEl) {
     if (currentEl === scopeRoot) {
-      return true;
+      return true
     } else if (isScopeBoundary(currentEl)) {
-      return false;
+      return false
     }
-    currentEl = currentEl.parentNode;
+    currentEl = currentEl.parentNode
   }
 
-  return false;
-};
+  return false
+}
 
 const shallowEq = (a, b) => {
   const aKeys = keys(a), bKeys = keys(b)
@@ -141,7 +141,7 @@ extend(EventSource.prototype, {
           belongsToScope(ev)) {
           o.onNext(ev)
         } else {
-          return null;
+          return null
         }
       },
       completed: () => o && o.onCompleted()
@@ -173,8 +173,8 @@ const Prepared = React.createClass({
     this.props.events.unmount(this)
   },
   render() {
-    const children = this.props.children;
-    const bondaryMarker = {[boundaryMakerAttr]: true};
+    const children = this.props.children
+    const bondaryMarker = {[boundaryMakerAttr]: true}
     return !this.state ? 
       React.cloneElement(children, bondaryMarker) :
       React.cloneElement(children, {...this.state.listeners, ...bondaryMarker})

--- a/src/index.js
+++ b/src/index.js
@@ -23,11 +23,11 @@ const boundaryMakerAttr = "data-scope-boundary";
 
 const isScopeBoundary = (el) => el.hasAttribute && el.hasAttribute(boundaryMakerAttr);
 
-const belongsToScope = (velems, ev) => {
-  const elems = velems.map(DOM.findDOMNode);
+const belongsToScope = (ev) => {
+  const scopeRoot = ev.currentTarget;
   let currentEl = ev.target;
   while(currentEl) {
-    if (elems.indexOf(currentEl) > -1) {
+    if (currentEl === scopeRoot) {
       return true;
     } else if (isScopeBoundary(currentEl)) {
       return false;
@@ -138,7 +138,7 @@ extend(EventSource.prototype, {
     const observer = o => ({
       next: ev => {
         if (o && matches(ev, selector) && 
-          belongsToScope(this.elems, ev)) {
+          belongsToScope(ev)) {
           o.onNext(ev)
         } else {
           return null;

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,25 @@ const extend = Object.assign
 
 const matches = (ev, sel) => !sel || (ev.target && selmatch(ev.target, sel))
 
+const boundaryMakerAttr = "data-scope-boundary";
+
+const isScopeBoundary = (el) => el.hasAttribute && el.hasAttribute(boundaryMakerAttr);
+
+const belongsToScope = (velems, ev) => {
+  const elems = velems.map(DOM.findDOMNode);
+  let currentEl = ev.target;
+  while(currentEl) {
+    if (elems.indexOf(currentEl) > -1) {
+      return true;
+    } else if (isScopeBoundary(currentEl)) {
+      return false;
+    }
+    currentEl = currentEl.parentNode;
+  }
+
+  return false;
+};
+
 const shallowEq = (a, b) => {
   const aKeys = keys(a), bKeys = keys(b)
   if (aKeys.length !== bKeys.length) return false
@@ -117,7 +136,14 @@ extend(EventSource.prototype, {
   },
   subscribe(selector, eventName) {
     const observer = o => ({
-      next: ev => matches(ev, selector) && o ? o.onNext(ev) : null,
+      next: ev => {
+        if (o && matches(ev, selector) && 
+          belongsToScope(this.elems, ev)) {
+          o.onNext(ev)
+        } else {
+          return null;
+        }
+      },
       completed: () => o && o.onCompleted()
     })
     const isNew = !(eventName in this.proxies)
@@ -147,8 +173,11 @@ const Prepared = React.createClass({
     this.props.events.unmount(this)
   },
   render() {
-    return !this.state ? this.props.children
-      : React.cloneElement(this.props.children, this.state.listeners)
+    const children = this.props.children;
+    const bondaryMarker = {[boundaryMakerAttr]: true};
+    return !this.state ? 
+      React.cloneElement(children, bondaryMarker) :
+      React.cloneElement(children, {...this.state.listeners, ...bondaryMarker})
   }
 })
 


### PR DESCRIPTION
Currently if a parent component is listening for event's via a selector that matches an element of a child component it will receive the events of that element as well.

This changes fixes this by marking the root elements of components with a marker attribute.
When the event occurs the dom tree is traversed upwards starting from the `event.target`. If an element with a marker attribute is hit before the `event.currentTarget` (which is the root element of the listening component) is hit the event processing will be canceled.

**Note:** This requires the child component to call `DOM.prepare` on it's `vtree$` stream in order to mark it's root node as component boundary.
